### PR TITLE
Added 'limit' configuration in filament-laravel-log.php and updated...

### DIFF
--- a/config/filament-laravel-log.php
+++ b/config/filament-laravel-log.php
@@ -17,7 +17,7 @@ return [
     'fontSize' => 12,
 
     /**
-     * Number of rows in the search bar
+     * Limit the number of results returned from the search.
      */
-    'searchBarRows' => 5,
+    'limit' => 5,
 ];

--- a/config/filament-laravel-log.php
+++ b/config/filament-laravel-log.php
@@ -15,4 +15,9 @@ return [
      * Editor font size.
      */
     'fontSize' => 12,
+
+    /**
+     * Number of rows in the search bar
+     */
+    'searchBarRows' => 5,
 ];

--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -29,7 +29,7 @@ class ViewLog extends Page
                     ->placeholder(fn (): string => __('log::filament-laravel-log.page.form.placeholder'))
                     ->live()
                     ->options(
-                        fn () => $this->getFileNames($this->getFinder())->take(config('filament-laravel-log.searchBarRows'))
+                        fn () => $this->getFileNames($this->getFinder())->take(config('filament-laravel-log.limit'))
                     )
                     ->searchable()
                     ->getSearchResultsUsing(

--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -29,7 +29,7 @@ class ViewLog extends Page
                     ->placeholder(fn (): string => __('log::filament-laravel-log.page.form.placeholder'))
                     ->live()
                     ->options(
-                        fn () => $this->getFileNames($this->getFinder())->take(5)
+                        fn () => $this->getFileNames($this->getFinder())->take(config('filament-laravel-log.searchBarRows'))
                     )
                     ->searchable()
                     ->getSearchResultsUsing(


### PR DESCRIPTION
Added 'searchBarRows' configuration in filament-laravel-log.php and updated ViewLog.php to dynamically use this value in the search bar:

- Introduced new 'searchBarRows' configuration setting to define the number of rows in the search bar.
- Modified ViewLog.php to dynamically retrieve and utilize the 'searchBarRows' value from the configuration file, replacing the previous static value.