### PR TITLE
Fix: Authorization lifecycle

### DIFF
--- a/src/FilamentLaravelLogPlugin.php
+++ b/src/FilamentLaravelLogPlugin.php
@@ -47,10 +47,6 @@ class FilamentLaravelLogPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        if (! $this->isAuthorized()) {
-            return;
-        }
-
         $panel
             ->pages([
                 $this->viewLog,

--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -114,4 +114,9 @@ class ViewLog extends Page
     {
         return __('log::filament-laravel-log.page.title');
     }
+
+    public static function canAccess(): bool
+    {
+        return FilamentLaravelLogPlugin::get()->isAuthorized();
+    }
 }


### PR DESCRIPTION
Moves the authorization check out of the plugin class and checks it in the ViewLog class instead to guarantee there is an authenticated user.

Resolves #32 