### PR TITLE
Modify log content in descending order before returning

### DIFF
--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -46,7 +46,11 @@ class ViewLog extends Page
             return '';
         }
 
-        return File::get($this->logFile);
+        $logContent = File::get($this->logFile);
+
+        $logEntries = preg_split('/(?=\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\])/', $logContent, -1, PREG_SPLIT_NO_EMPTY);
+
+        return collect($logEntries)->reverse()->join("\n");
     }
 
     public function clear(): void


### PR DESCRIPTION
This PR adds a PHP script to reverse Laravel log entries while preserving the original format, including timestamps and structure. The log entries are now displayed in descending order, with the most recent logs appearing first. This enhancement improves log readability, especially for troubleshooting recent issues.

Key Changes:
- Utilizes preg_split() to split log entries based on their timestamp.

- Reverses the order of log entries using array_reverse().

- Ensures that log format and timestamps are preserved.