### PR TITLE
Laravel 12 Compatibility

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,9 +1,12 @@
-name: Check & fix styling
+name: Fix PHP code style issues
 
-on: [push]
+on:
+  push:
+    paths:
+      - '**.php'
 
 jobs:
-  php-cs-fixer:
+  php-code-styling:
     runs-on: ubuntu-latest
 
     steps:
@@ -12,10 +15,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Run PHP CS Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga
-        with:
-          args: --config=.php_cs.dist.php --allow-risky=yes
+      - name: Fix PHP code style issues
+        uses: aglipanci/laravel-pint-action@2.5
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,14 +13,21 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0]
-        laravel: [10.*, 11.*]
+        php: [8.4, 8.3, 8.2, 8.1]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+        exclude:
+          - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,21 +13,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
-        exclude:
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,12 @@
 {
     "name": "saade/filament-laravel-log",
     "description": "Access laravel.log file through Filament admin panel",
+    "license": "MIT",
     "keywords": [
         "saade",
         "laravel",
         "filament-laravel-log"
     ],
-    "homepage": "https://github.com/saade/filament-laravel-log",
-    "support": {
-        "issues": "https://github.com/saade/filament-laravel-log/issues",
-        "source": "https://github.com/saade/filament-laravel-log"
-    },
-    "license": "MIT",
     "authors": [
         {
             "name": "Saade",
@@ -19,17 +14,22 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://github.com/saade/filament-laravel-log",
+    "support": {
+        "issues": "https://github.com/saade/filament-laravel-log/issues",
+        "source": "https://github.com/saade/filament-laravel-log"
+    },
     "require": {
         "php": "^8.1",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0|^8.0",
+        "nunomaduro/collision": "^7.0 || ^8.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0|^9.0",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
@@ -38,6 +38,8 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "spatie/laravel-ray": "^1.26"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Saade\\FilamentLaravelLog\\": "src/"
@@ -48,19 +50,12 @@
             "Saade\\FilamentLaravelLog\\Tests\\": "tests/"
         }
     },
-    "scripts": {
-        "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-        "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint"
-    },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "laravel": {
@@ -69,6 +64,11 @@
             ]
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "scripts": {
+        "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
+        "analyse": "vendor/bin/phpstan analyse",
+        "format": "vendor/bin/pint",
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
         "source": "https://github.com/saade/filament-laravel-log"
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/contracts": "^11.0 || ^12.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.1.0",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0 || ^8.0",
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^9.0 || ^10.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,16 @@
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
+        "larastan/larastan": "^3.1.0",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0 || ^8.0",
-        "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0.1",
+        "phpstan/phpstan-phpunit": "^2.0.4",
         "spatie/laravel-ray": "^1.26"
     },
     "minimum-stability": "dev",
@@ -66,7 +66,7 @@
     },
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-        "analyse": "vendor/bin/phpstan analyse",
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=512M",
         "format": "vendor/bin/pint",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,12 +2,10 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 4
+    level: 5
     paths:
         - src
         - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false

--- a/pint.json
+++ b/pint.json
@@ -1,5 +1,8 @@
 {
     "preset": "laravel",
+    "exclude": [
+        "build"
+    ],
     "rules": {
         "blank_line_before_statement": true,
         "concat_space": {

--- a/src/FilamentLaravelLogPlugin.php
+++ b/src/FilamentLaravelLogPlugin.php
@@ -4,6 +4,7 @@ namespace Saade\FilamentLaravelLog;
 
 use Closure;
 use Filament\Contracts\Plugin;
+use Filament\FilamentManager;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Saade\FilamentLaravelLog\Pages\ViewLog;
@@ -40,7 +41,7 @@ class FilamentLaravelLogPlugin implements Plugin
         return app(static::class);
     }
 
-    public static function get(): static
+    public static function get(): FilamentManager | static
     {
         return filament(app(static::class)->getId());
     }

--- a/src/FilamentLaravelLogPlugin.php
+++ b/src/FilamentLaravelLogPlugin.php
@@ -55,7 +55,7 @@ class FilamentLaravelLogPlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
-        if(! $this->getLogDirs()){
+        if (! $this->getLogDirs()) {
             $this->logDirs([
                 storage_path('logs'),
             ]);

--- a/src/FilamentLaravelLogServiceProvider.php
+++ b/src/FilamentLaravelLogServiceProvider.php
@@ -38,9 +38,7 @@ class FilamentLaravelLogServiceProvider extends PackageServiceProvider
         }
     }
 
-    public function packageRegistered(): void
-    {
-    }
+    public function packageRegistered(): void {}
 
     public function packageBooted(): void
     {

--- a/src/Pages/Concerns/HasActions.php
+++ b/src/Pages/Concerns/HasActions.php
@@ -75,7 +75,7 @@ trait HasActions
 
     public function refreshAction(): Action
     {
-        return $action = RefreshAction::make();
+        $action = RefreshAction::make();
 
         if ($this->modifyRefreshActionUsing) {
             $action = $this->evaluate($this->modifyRefreshActionUsing, [
@@ -88,7 +88,7 @@ trait HasActions
 
     public function modifyClearAction(?Closure $callback): static
     {
-        $this->modifyclearActionUsing = $callback;
+        $this->modifyClearActionUsing = $callback;
 
         return $this;
     }
@@ -103,6 +103,13 @@ trait HasActions
     public function modifyJumpToEndAction(?Closure $callback): static
     {
         $this->modifyJumpToEndActionUsing = $callback;
+
+        return $this;
+    }
+
+    public function modifyRefreshAction(?Closure $callback): static
+    {
+        $this->modifyRefreshActionUsing = $callback;
 
         return $this;
     }

--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -43,6 +43,7 @@ class ViewLog extends Page
     {
         if (! $this->logFile || ! $this->fileResidesInLogDirs($this->logFile)) {
             $this->logFile = null;
+
             return '';
         }
 
@@ -53,6 +54,7 @@ class ViewLog extends Page
     {
         if (! $this->logFile || ! $this->fileResidesInLogDirs($this->logFile)) {
             $this->logFile = null;
+
             return;
         }
 

--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -25,7 +25,7 @@ class ViewLog extends Page
         return $form
             ->schema([
                 Forms\Components\Select::make('logFile')
-                    ->label(false)
+                    ->label(null)
                     ->placeholder(fn (): string => __('log::filament-laravel-log.page.form.placeholder'))
                     ->live()
                     ->options(
@@ -59,6 +59,7 @@ class ViewLog extends Page
         }
 
         File::put($this->logFile, '');
+
         $this->refresh();
     }
 


### PR DESCRIPTION
This pull request includes several updates to workflows, dependencies, and code style improvements. The most important changes involve renaming and updating GitHub workflow files, updating PHP and Laravel versions, and modifying the `composer.json` file to reflect these changes.

Important note: This PR drops support for PHP 8.1 and Laravel 10

### Workflow updates:
* Renamed `.github/workflows/php-cs-fixer.yml` to `.github/workflows/fix-php-code-style-issues.yml` and updated the job name and trigger paths. Changed the action used to fix PHP code style issues to `aglipanci/laravel-pint-action@2.5`. [[1]](diffhunk://#diff-1fe0287e0253ce9640da25ffe9449e0b9ec6d39929535e1dd03eb85dfeecfd2aL1-R9) [[2]](diffhunk://#diff-1fe0287e0253ce9640da25ffe9449e0b9ec6d39929535e1dd03eb85dfeecfd2aL15-R19)
* Updated the PHP version in `.github/workflows/phpstan.yml` to `8.2`.
* Updated the PHP and Laravel versions in `.github/workflows/run-tests.yml` to include newer versions.

### Dependency updates:
* Updated `composer.json` to require PHP `^8.2` and Laravel `^11.0 || ^12.0`. Added `larastan/larastan` as a development dependency and updated other dependencies to their latest versions.
* Reorganized and updated the `scripts` section in `composer.json` to include memory limits for `phpstan` and restored the `minimum-stability` and `prefer-stable` settings. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L51-R58) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L72-R73)

### Code style improvements:
* Updated `phpstan.neon.dist` to increase the analysis level from 4 to 5.
* Modified `pint.json` to exclude the `build` directory from Pint's code style checks.
* Various code improvements in `src/FilamentLaravelLogPlugin.php`, `src/FilamentLaravelLogServiceProvider.php`, `src/Pages/Concerns/HasActions.php`, and `src/Pages/ViewLog.php` to enhance readability and maintainability. [[1]](diffhunk://#diff-c8558149935a1283b6bddb53134259dc29955e8ce45830389b2e3fe5a37778f8R7) [[2]](diffhunk://#diff-c8558149935a1283b6bddb53134259dc29955e8ce45830389b2e3fe5a37778f8L43-R44) [[3]](diffhunk://#diff-c451f9116fba598f792e28a66fc69b0b94ec37422bca0732977ff7e178500de5L41-R41) [[4]](diffhunk://#diff-91ae5a9f18e8603ae45e820cbaf712abe48b486a73c1016717225f67c0f314b9L78-R78) [[5]](diffhunk://#diff-91ae5a9f18e8603ae45e820cbaf712abe48b486a73c1016717225f67c0f314b9L91-R91) [[6]](diffhunk://#diff-91ae5a9f18e8603ae45e820cbaf712abe48b486a73c1016717225f67c0f314b9R110-R116) [[7]](diffhunk://#diff-acc1c7d55ccea16d2159e63ca46d6ad98ac6704302ced1a250b7b4d549d9abe2L28-R28) [[8]](diffhunk://#diff-acc1c7d55ccea16d2159e63ca46d6ad98ac6704302ced1a250b7b4d549d9abe2R46) [[9]](diffhunk://#diff-acc1c7d55ccea16d2159e63ca46d6ad98ac6704302ced1a250b7b4d549d9abe2R57-R62)