### PR TITLE
Laravel 13 support (3.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^11.0 || ^12.0",
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
Adds `^13.0` to the illuminate/contracts constraint so the package installs on Laravel 13. Constraint-only change — no source changes; nothing in this package touches API that changed between Laravel 12 and 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)